### PR TITLE
Make Richelot isogeny chains subquadratic

### DIFF
--- a/richelot_aux.sage
+++ b/richelot_aux.sage
@@ -127,12 +127,14 @@ def FromJacToJac(h, D11, D12, D21, D22, a, power=None):
     next_power = None
     if power is None:
         # Precompute some power of D1, D2 to save computations later.
+        # We are going to perform O(a^1.5) squarings instead of O(a^2)
         if a >= 16:
-            _D1 = 2^(a-8)*D1
-            _D2 = 2^(a-8)*D2
-            G1, _ = 2^7 * _D1
-            G2, _ = 2^7 * _D2
-            next_power = (a-8, _D1, _D2)
+            gap = Integer(2*a).isqrt()
+            _D1 = 2^(a-gap)*D1
+            _D2 = 2^(a-gap)*D2
+            G1, _ = 2^(gap-1) * _D1
+            G2, _ = 2^(gap-1) * _D2
+            next_power = (a-gap, _D1, _D2)
         else:
             G1, _ = 2^(a-1) * D1
             G2, _ = 2^(a-1) * D2


### PR DESCRIPTION
The previous patch reduced the number of squaring operations
in the Jacobian from n^2/2 to about n^2/16 + 4*n.

By adjusting which point power is cached and passed to
the next iteration we can obtain a O(n^1.5) complexity.

This provides a modest 10-15% speedup for large keys.