### PR TITLE
Speedup: Hard-code dimension of curve

### DIFF
--- a/speedup.sage
+++ b/speedup.sage
@@ -17,5 +17,9 @@ def _do_speedup():
     # as all types share the same method, by identity
     # Something to be explored later, perhaps :)
     
+    # No use calculating the dimension of HyperElliptic every single time
+    from sage.schemes.projective.projective_subscheme import AlgebraicScheme_subscheme_projective
+    AlgebraicScheme_subscheme_projective.dimension = lambda self: 1
+    
 
 _do_speedup()


### PR DESCRIPTION
When calculating the Jacobi, the dimension is always recalculated in a very generic way. This patch hard-codes it, which works with the attack, but will surely break other things not related to the attack.