### PR TITLE
speedups in elliptic-curve arithmetic

### DIFF
--- a/castryck_decru_attack.sage
+++ b/castryck_decru_attack.sage
@@ -51,9 +51,8 @@ def CastryckDecruAttack(E_start, P2, Q2, EB, PB, QB, two_i):
         print(f"Testing digits: {[first_digits[k] for k in range(bet1)]}")
 
         # tauhatkernel = 3^bi*P3 + sum([3^(k-1)*j[k-1] for k in range(1,beta+1)])*3^bi*Q3
-        tauhatkernel = 3^bi*P3 
-        for k in range(1, bet1+1):
-            tauhatkernel += (3^(k-1)*first_digits[k-1])*3^bi*Q3
+        scalar = sum(3^k*d for k,d in enumerate(first_digits))
+        tauhatkernel = 3^bi * (P3 + scalar*Q3)
 
         tauhatkernel_distort = u*tauhatkernel + v*two_i(tauhatkernel)
 
@@ -108,10 +107,8 @@ def CastryckDecruAttack(E_start, P2, Q2, EB, PB, QB, two_i):
     for j in range(0,3):
         print(f"Testing digit: {j}")
         # tauhatkernel := 3^bi*P3 + (&+[3^(k-1)*skB[k] : k in [1..i-1]] + 3^(i-1)*j)*3^bi*Q3;
-        tauhatkernel = 3^bi*P3 
-        for k in range(1, i):
-            tauhatkernel += (3^(k-1)*skB[k-1])*3^bi*Q3
-        tauhatkernel += 3^(i-1)*j*3^bi*Q3
+        scalar = sum(3^k*d for k,d in enumerate(skB)) + 3^(i-1)*j
+        tauhatkernel = 3^bi * (P3 + scalar*Q3)
 
         C, P_c, Q_c = AuxiliaryIsogeny(i, u, v, E_start, P2, Q2, tauhatkernel, two_i)
 
@@ -176,10 +173,8 @@ def CastryckDecruAttack(E_start, P2, Q2, EB, PB, QB, two_i):
                 break
 
             # tauhatkernel := 3^bi*P3 + (&+[3^(k-1)*skB[k] : k in [1..i-1]] + 3^(i-1)*j)*3^bi*Q3;
-            tauhatkernel = 3^bi*P3 
-            for k in range(1, i):
-                tauhatkernel += (3^(k-1)*skB[k-1])*3^bi*Q3
-            tauhatkernel += 3^(i-1)*j*3^bi*Q3
+            scalar = sum(3^k*d for k,d in enumerate(skB)) + 3^(i-1)*j
+            tauhatkernel = 3^bi * (P3 + scalar * Q3)
 
             C, P_c, Q_c = AuxiliaryIsogeny(i, u, v, E_start, P2, Q2, tauhatkernel, two_i)
 

--- a/castryck_decru_attack.sage
+++ b/castryck_decru_attack.sage
@@ -100,7 +100,7 @@ def CastryckDecruAttack(E_start, P2, Q2, EB, PB, QB, two_i):
     endQB = EBprolong[0](QB)
     endEB = EBprolong[0].codomain()
     # Speeds things up in Sage
-    endEB.set_order((p+1)^2)
+    endEB.set_order((p+1)^2, num_checks=0)
 
     positives = []
 
@@ -161,7 +161,7 @@ def CastryckDecruAttack(E_start, P2, Q2, EB, PB, QB, two_i):
         if j == prolong:
             endEB = EBprolong[j-1].codomain()
             # Speeds things up in Sage
-            endEB.set_order((p+1)^2)
+            endEB.set_order((p+1)^2, num_checks=0)
 
 
         for j in range(0,3):

--- a/richelot_aux.sage
+++ b/richelot_aux.sage
@@ -307,20 +307,32 @@ def OddCyclicSumOfSquares(n, factexpl, provide_own_fac):
 
 def Pushing3Chain(E, P, i):
     """
-    Compute chain of isogenies quotienting 
+    Compute chain of isogenies quotienting
     out a point P of order 3^i
+
+    https://trac.sagemath.org/ticket/34239
     """
-    chain = []
-    C = E
-    remainingker = P
-    # for j in [1..i] do
-    for j in range(1, i+1):
-        ker = 3^(i-j)*remainingker
-        comp = EllipticCurveIsogeny(C, [ker], degree=3, check=False)
-        C = comp.codomain()
-        remainingker = comp(remainingker)
-        chain.append(comp)
-    return C, chain
+    def rec(Q, k):
+        assert k
+        if k == 1:  # base case
+#            assert Q and not 3*Q
+            return [EllipticCurveIsogeny(Q.curve(), Q, degree=3, check=False)]
+
+        k1 = int(k * .8 + .5)
+        k1 = max(1, min(k-1, k1))  # clamp to [1, k-1]
+
+        Q1 = 3^k1 * Q
+        L = rec(Q1, k-k1)
+
+        Q2 = Q
+        for psi in L:
+            Q2 = psi(Q2)
+        R = rec(Q2, k1)
+
+        return L + R
+
+    chain = rec(P, i)
+    return chain[-1].codomain(), chain
 
 def AuxiliaryIsogeny(i, u, v, E_start, P2, Q2, tauhatkernel, two_i):
     """


### PR DESCRIPTION
This patch applies three independent performance optimizations to the elliptic-curve parts of the attack:

* `3^n`-isogeny chains benefit from sparse evaluation strategies (which were also used in SIDH constructively). Implemented [here](https://trac.sagemath.org/ticket/34239), but not yet merged into Sage.
* Instead of combining partial sums of `tauhatkernel` *as curve points*, we can simplify the sum on integers first and perform fewer expensive operations on curve points this way.
* `.set_order()` by default runs some trial scalar multiplications as a sanity check, which can be disabled by setting the optional `num_checks` argument to `0`.

Together, these changes yield a ~1.2× speedup for breaking SIKEp434.