### PR TITLE
make sure serial implementation uses only its own process

### DIFF
--- a/castryck_decru_attack.sage
+++ b/castryck_decru_attack.sage
@@ -15,7 +15,8 @@ def possibly_parallel(num_cores):
             def _fun(args):
                 for a in args:
                     yield ((a,), None), fun(a)
-            return _wrap
+            return _fun
+        return _wrap
     return parallel(num_cores)
 
 def CastryckDecruAttack(E_start, P2, Q2, EB, PB, QB, two_i, num_cores=1):


### PR DESCRIPTION
A typo in #15 means that `possibly_parallel` actually always ended up calling `parallel`, rather than avoiding `multiprocessing` stuff altogether when `num_cores == 1`.